### PR TITLE
feat: add coinflip game

### DIFF
--- a/commands/games/coinflip.js
+++ b/commands/games/coinflip.js
@@ -1,0 +1,49 @@
+const { EmbedBuilder } = require("discord.js");
+const { useFunctions } = require("@zibot/zihooks");
+
+module.exports.data = {
+	name: "coinflip",
+	description: "Trò chơi tung đồng xu",
+	type: 1,
+	options: [
+		{
+			name: "side",
+			description: "Chọn mặt đồng xu",
+			type: 3,
+			required: true,
+			choices: [
+				{ name: "Ngửa", value: "heads" },
+				{ name: "Sấp", value: "tails" },
+			],
+		},
+	],
+	integration_types: [0],
+	contexts: [0, 1],
+};
+
+/**
+ * @param { object } command - object command
+ * @param { import("discord.js").CommandInteraction } command.interaction - interaction
+ * @param { import("../../lang/vi.js") } command.lang - language
+ */
+module.exports.execute = async ({ interaction, lang }) => {
+	const ZiRank = useFunctions().get("ZiRank");
+	const choice = interaction.options.getString("side");
+	const result = Math.random() < 0.5 ? "heads" : "tails";
+	const win = choice === result;
+	const words = lang?.Coinflip ?? {};
+	const displayChoice = choice === "heads" ? (words.head ?? "Heads") : (words.tail ?? "Tails");
+	const displayResult = result === "heads" ? (words.head ?? "Heads") : (words.tail ?? "Tails");
+	const message = win ? (words.win ?? "You guessed correctly!") : (words.lose ?? "You guessed wrong!");
+
+	const embed = new EmbedBuilder()
+		.setTitle("Coinflip")
+		.setColor("#5865F2")
+		.setDescription(
+			`${words.chosen ?? "Bạn chọn"}: **${displayChoice}**\n${words.result ?? "Kết quả"}: **${displayResult}**\n${message}`,
+		);
+
+	await interaction.reply({ embeds: [embed] });
+	const CoinADD = win ? 100 : -100;
+	await ZiRank.execute({ user: interaction.user, XpADD: 0, CoinADD });
+};

--- a/lang/en.js
+++ b/lang/en.js
@@ -51,6 +51,14 @@ module.exports = {
 		timeoutMessage: "The Game went unfinished! No one won the Game!",
 		playerOnlyMessage: "Only {player} and {opponent} can use these buttons.",
 	},
+	Coinflip: {
+		chosen: "You chose",
+		result: "Result",
+		head: "Heads",
+		tail: "Tails",
+		win: "You guessed correctly!",
+		lose: "You guessed wrong!",
+	},
 	Ping: {
 		Description: "Hey ##username##! Here's my **latency** and **ping** status:",
 		Roundtrip: "🔄 Round-trip Latency",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -51,6 +51,14 @@ module.exports = {
 		timeoutMessage: "Trò chơi bị bỏ dở! Không ai thắng!",
 		playerOnlyMessage: "Chỉ {player} và {opponent} mới có thể sử dụng các nút này.",
 	},
+	Coinflip: {
+		chosen: "Bạn chọn",
+		result: "Kết quả",
+		head: "Ngửa",
+		tail: "Sấp",
+		win: "Bạn đã đoán đúng!",
+		lose: "Bạn đã đoán sai!",
+	},
 	Ping: {
 		Description: "Chào ##username##! Đây là **độ trễ** và trạng thái **ping** của tôi:",
 		Roundtrip: "🔄 Độ trễ vòng lặp",


### PR DESCRIPTION
## Summary
- add coinflip game command where users pick a side
- provide English and Vietnamese responses for coinflip

## Testing
- `npm run check`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fa05900c83209c8ec9570bb4647f