### PR TITLE
feat: add over/under dice game

### DIFF
--- a/commands/games/overunder.js
+++ b/commands/games/overunder.js
@@ -1,0 +1,84 @@
+const { EmbedBuilder } = require("discord.js");
+const { useFunctions, useDB } = require("@zibot/zihooks");
+
+module.exports.data = {
+	name: "overunder",
+	description: "Trò chơi lắc xúc xắc Over/Under",
+	type: 1,
+	options: [
+		{
+			name: "choice",
+			description: "Chọn over hay under",
+			type: 3,
+			required: true,
+			choices: [
+				{ name: "Over", value: "over" },
+				{ name: "Under", value: "under" },
+			],
+		},
+		{
+			name: "bet",
+			description: "Số coin cược hoặc 'all'",
+			type: 3,
+			required: false,
+		},
+	],
+	integration_types: [0],
+	contexts: [0, 1],
+};
+
+/**
+ * @param { object } command - object command
+ * @param { import("discord.js").CommandInteraction } command.interaction - interaction
+ * @param { import("../../lang/vi.js") } command.lang - language
+ */
+module.exports.execute = async ({ interaction, lang }) => {
+	const ZiRank = useFunctions().get("ZiRank");
+	const db = useDB();
+	const choice = interaction.options.getString("choice");
+	const betInput = interaction.options.getString("bet");
+
+	let bet = 100;
+	if (betInput) {
+		if (betInput.toLowerCase() === "all") {
+			bet = db ? (await db.ZiUser.findOne({ userID: interaction.user.id }))?.coin || 0 : 0;
+		} else {
+			const parsed = parseInt(betInput, 10);
+			if (isNaN(parsed) || parsed <= 0) {
+				return interaction.reply({ content: "Bet amount must be a positive number.", ephemeral: true });
+			}
+			bet = parsed;
+		}
+	}
+	const dice1 = Math.floor(Math.random() * 6) + 1;
+	const dice2 = Math.floor(Math.random() * 6) + 1;
+	const total = dice1 + dice2;
+	const isOver = total >= 8;
+	const isUnder = total <= 6;
+	const isTie = total === 7;
+	const win = (choice === "over" && isOver) || (choice === "under" && isUnder);
+	const words = lang?.OverUnder ?? {};
+	const displayChoice = choice === "over" ? (words.over ?? "Over") : (words.under ?? "Under");
+	const resultText =
+		isTie ? (words.exactly ?? "It's exactly 7!")
+		: isOver ? (words.over ?? "Over")
+		: (words.under ?? "Under");
+	const message =
+		isTie ? (words.tie ?? "It's a tie! No coins lost.")
+		: win ? (words.win ?? "You won!")
+		: (words.lose ?? "You lost!");
+
+	const embed = new EmbedBuilder()
+		.setTitle("Over/Under")
+		.setColor("#5865F2")
+		.setDescription(
+			`${words.chosen ?? "Bạn chọn"}: **${displayChoice}**\n${words.result ?? "Kết quả"}: **${total} (${resultText})**\n${words.bet ?? "Tiền cược"}: **${bet}**\n${message}`,
+		);
+
+	await interaction.reply({ embeds: [embed] });
+	const CoinADD =
+		isTie ? 0
+		: win ? bet * 2
+		: -bet;
+	await ZiRank.execute({ user: interaction.user, XpADD: 0, CoinADD });
+};

--- a/lang/en.js
+++ b/lang/en.js
@@ -59,6 +59,17 @@ module.exports = {
 		win: "You guessed correctly!",
 		lose: "You guessed wrong!",
 	},
+	OverUnder: {
+		chosen: "You chose",
+		result: "Result",
+		over: "Over (8-12)",
+		under: "Under (2-6)",
+		exactly: "It's exactly 7!",
+		tie: "It's a tie! No coins lost.",
+		win: "You won!",
+		lose: "You lost!",
+		bet: "Bet",
+	},
 	Ping: {
 		Description: "Hey ##username##! Here's my **latency** and **ping** status:",
 		Roundtrip: "🔄 Round-trip Latency",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -59,6 +59,17 @@ module.exports = {
 		win: "Bạn đã đoán đúng!",
 		lose: "Bạn đã đoán sai!",
 	},
+	OverUnder: {
+		chosen: "Bạn chọn",
+		result: "Kết quả",
+		over: "Tài (8-12)",
+		under: "Xỉu (2-6)",
+		exactly: "Ra đúng 7!",
+		tie: "Hòa! Bạn không mất coin.",
+		win: "Bạn thắng!",
+		lose: "Bạn thua!",
+		bet: "Tiền cược",
+	},
 	Ping: {
 		Description: "Chào ##username##! Đây là **độ trễ** và trạng thái **ping** của tôi:",
 		Roundtrip: "🔄 Độ trễ vòng lặp",


### PR DESCRIPTION
## Summary
- refine over/under dice mini-game: totals 2-6 under, 8-12 over, tie on 7
- update coin rewards to +200/-100 with no change on ties
- localize over/under strings with new ranges and tie message in English and Vietnamese
- add optional bet parameter allowing custom wagers or all-in, defaulting to +200/-100/0 when omitted

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b52542832c8320b1c524f9141e680c