### PR TITLE
feat: allow optional user mention in fact command

### DIFF
--- a/commands/fun/fact.js
+++ b/commands/fun/fact.js
@@ -2,10 +2,34 @@ const { joinVoiceChannel, createAudioPlayer, createAudioResource, AudioPlayerSta
 const path = require("path");
 
 module.exports.data = {
-	name: "duysuy",
-	description: "Phát audio duysuy hoặc gửi lời động viên",
+	name: "fact",
+	description: "Phát audio duysuy hoặc gửi lời nhắn của bạn.",
 	type: 1,
-	options: [],
+	options: [
+		{
+			name: "option",
+			description: "Chọn hành động",
+			type: 3,
+			required: true,
+			choices: [{ name: "reply muon", value: "replymuon" }],
+		},
+		{
+			name: "user",
+			description: "Người sẽ được tag trong tin nhắn",
+			type: 6,
+			required: false,
+		},
+		// {
+		//     name: "another_option",
+		//     description: "Ví dụ option khác",
+		//     type: 3,
+		// },
+		// {
+		//     name: "more_option",
+		//     description: "Một option dự phòng",
+		//     type: 3,
+		// },
+	],
 	integration_types: [0],
 	contexts: [0],
 };
@@ -15,11 +39,19 @@ module.exports.data = {
  * @param { import("discord.js").CommandInteraction } command.interaction
  */
 module.exports.execute = async ({ interaction }) => {
+	const option = interaction.options.getString("option");
+	const targetUser = interaction.options.getUser("user");
+	if (option !== "replymuon") return;
+
 	const voiceChannel = interaction.member?.voice?.channel;
 	if (!voiceChannel) {
-		await interaction.reply("Duy chỉ hơi suy thôi rồi từ từ mọi thứ sẽ qua, chỉ có vết thương lòng còn ở đó 💔");
+		let message =
+			"Tại sao bạn lại tệ đến mức như vậy?? Tôi coi bạn quan trọng luôn rep bạn sớm mà bạn lại để tôi chờ đợi vậy sao?";
+		if (targetUser) message += ` ${targetUser}`;
+		await interaction.reply(message);
 		return;
 	}
+
 	await interaction.deferReply({ ephemeral: true }).catch(() => {});
 	const connection = joinVoiceChannel({
 		channelId: voiceChannel.id,

--- a/functions/SelectMenu/S_Help.js
+++ b/functions/SelectMenu/S_Help.js
@@ -36,14 +36,24 @@ module.exports.execute = async ({ interaction, lang }) => {
 				`# ${lang.Help.GuildCommands}:\n\n` +
 					guildCommands
 						.map((cmd) => {
-							if (cmd.options?.at(0).type == 1) {
-								let optionss = "";
-								for (const option of cmd.options) {
-									if (option.type == 1) {
-										optionss += `</${cmd.name} ${option.name}:${cmd.id}>: ${option.description}\n`;
+							if (cmd.options?.length) {
+								if (cmd.options.some((opt) => opt.type == 1)) {
+									let optionss = "";
+									for (const option of cmd.options) {
+										if (option.type == 1) {
+											optionss += `</${cmd.name} ${option.name}:${cmd.id}>: ${option.description}\n`;
+										}
 									}
+									return optionss;
 								}
-								return optionss;
+								const optionsText = cmd.options
+									.filter((opt) => opt.type != 1)
+									.map((opt) => {
+										const choices = opt.choices?.map((c) => c.name).join(" | ");
+										return ` - ${opt.name}${opt.required ? "*" : ""}: ${opt.description}${choices ? ` (${choices})` : ""}`;
+									})
+									.join("\n");
+								return `</${cmd.name}:${cmd.id}>: ${cmd.description}\n${optionsText}\n`;
 							}
 							return `</${cmd.name}:${cmd.id}>: ${cmd.description}\n`;
 						})


### PR DESCRIPTION
## Summary
- require "reply muon" option for /fact and allow tagging a user
- reply with a fixed late-response message if user not in voice
- still play `duysuy.mp3` in voice channels and keep placeholder options
- show command options and choice names in help output

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68be533e9e1c8320a88219747132bc1a